### PR TITLE
renovate.json: use config:js-lib instead of config:base

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:js-lib"
   ],
   "baseBranches": ["master", "next"],
   "packageRules": [


### PR DESCRIPTION
This uses:
{
  "extends": [
    "config:base",
    ":pinOnlyDevDependencies"
  ]
}
which makes more sense for a library.
https://docs.renovatebot.com/presets-config/#configjs-lib