### PR TITLE
renovate.json: use config:js-lib instead of config:base

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/ecamp/hal-json-vuex#readme",
   "dependencies": {
-    "hal-json-normalizer": "4.0.3",
-    "url-template": "2.0.8"
+    "hal-json-normalizer": "^4.0.3",
+    "url-template": "^2.0.8"
   },
   "devDependencies": {
     "@babel/plugin-transform-regenerator": "7.14.5",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:js-lib"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Also unpin the dependencies.
This uses:
{
  "extends": [
    "config:base",
    ":pinOnlyDevDependencies"
  ]
}
which makes more sense for a library.
https://docs.renovatebot.com/presets-config/#configjs-lib