### PR TITLE
Handle array properties correctly

### DIFF
--- a/src/StoreValue.js
+++ b/src/StoreValue.js
@@ -22,7 +22,7 @@ class StoreValue extends CanHaveItems {
       if (key === 'allItems' && isCollection(data)) return
       if (key === 'items' && isCollection(data)) {
         this.addItemsGetter(data[key], data._meta.self, key)
-      } else if (Array.isArray(value)) {
+      } else if (Array.isArray(value) && value.length > 0 && isEntityReference(value[0])) { // need min. 1 item to detect an embedded collection
         this[key] = () => new EmbeddedCollection(value, data._meta.self, key, { get, reload, isUnknown }, config, data._meta.load)
       } else if (isEntityReference(value)) {
         this[key] = () => this.apiActions.get(value.href)

--- a/tests/resources/array-property.json
+++ b/tests/resources/array-property.json
@@ -1,0 +1,40 @@
+{
+  "serverResponse": {
+    "id": 1,
+    "arrayProperty": [
+      {
+        "a": 1,
+        "nested": [
+          {
+            "b": 2
+          }
+        ]
+      }
+    ],
+    "emptyArray": [],
+    "_links": {
+      "self": {
+        "href": "/camps/1"
+      }
+    }
+  },
+  "storeState": {
+    "/camps/1": {
+      "id": 1,
+      "arrayProperty": [
+        {
+          "a": 1,
+          "nested": [
+            {
+              "b": 2
+            }
+          ]
+        }
+      ],
+      "emptyArray": [],
+      "_meta": {
+        "self": "/camps/1"
+      }
+    }
+  }
+}

--- a/tests/resources/embedded-linked-collection.json
+++ b/tests/resources/embedded-linked-collection.json
@@ -1,0 +1,101 @@
+{
+  "serverResponse": {
+    "id": 1,
+    "_embedded": {
+      "periods": [
+        {
+          "id": 104,
+          "start": "01-01-2019",
+          "end": "03-01-2019",
+          "_links": {
+            "self": {
+              "href": "/periods/104"
+            },
+            "camp": {
+              "href": "/camps/1"
+            },
+            "activities": {
+              "href": "/periods/104/activities"
+            }
+          }
+        },
+        {
+          "id": 128,
+          "start": "12-04-2019",
+          "end": "19-04-2019",
+          "_links": {
+            "self": {
+              "href": "/periods/128"
+            },
+            "camp": {
+              "href": "/camps/1"
+            },
+            "activities": {
+              "href": "/periods/128/activities"
+            }
+          }
+        }
+      ]
+    },
+    "_links": {
+      "self": {
+        "href": "/camps/1"
+      },
+      "periods": {
+        "href": "/camps/1/periods"
+      }
+    }
+  },
+  "storeState": {
+    "/periods/104": {
+      "id": 104,
+      "start": "01-01-2019",
+      "end": "03-01-2019",
+      "camp": {
+        "href": "/camps/1"
+      },
+      "activities": {
+        "href": "/periods/104/activities"
+      },
+      "_meta": {
+        "self": "/periods/104"
+      }
+    },
+    "/periods/128": {
+      "id": 128,
+      "start": "12-04-2019",
+      "end": "19-04-2019",
+      "camp": {
+        "href": "/camps/1"
+      },
+      "activities": {
+        "href": "/periods/128/activities"
+      },
+      "_meta": {
+        "self": "/periods/128"
+      }
+    },
+    "/camps/1": {
+      "id": 1,
+      "periods": {
+        "href": "/camps/1/periods"
+      },
+      "_meta": {
+        "self": "/camps/1"
+      }
+    },
+    "/camps/1/periods": {
+      "_meta": {
+        "self": "/camps/1/periods"
+      },
+      "items": [
+        {
+          "href": "/periods/104"
+        },
+        {
+          "href": "/periods/128"
+        }
+      ]
+    }
+  }
+}

--- a/tests/resources/object-property.json
+++ b/tests/resources/object-property.json
@@ -1,0 +1,32 @@
+{
+  "serverResponse": {
+    "id": 1,
+    "objectProperty": {
+      "a": 1,
+      "nested": {
+        "b": 2
+      }
+    },
+    "emptyObject": {},
+    "_links": {
+      "self": {
+        "href": "/camps/1"
+      }
+    }
+  },
+  "storeState": {
+    "/camps/1": {
+      "id": 1,
+      "objectProperty": {
+        "a": 1,
+        "nested": {
+          "b": 2
+        }
+      },
+      "emptyObject": {},
+      "_meta": {
+        "self": "/camps/1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is needed because `columns` property on `ColumnLayout` now comes as a JSON array, which is treated as embedded collection by mistake. Previously the information came in a JSON object (`jsonConfig` property). 

There's an edge case which would now produce an error: If an empty embedded collection is provided, there's currently no chance this would be identified as an embedded collection, as this information is already taken away by the normalizer. This probably throws a console error, because the developer would expect a function (embedded collection) but would receive an empty array.

Shouldn't be a problem for us at the moment, because we always provide links for embedded collections, in which case the empty array is already replaced by the normalizer by the link and everything works fine. 

