### PR TITLE
chore: error message improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
+    "build-dev": "cross-env NODE_ENV=development webpack",
     "clean": "cross-env rimraf dist coverage lib",
     "coverage": "cross-env npm run build && jest --coverage",
     "lint": "cross-env eslint src --ext .js,.ts",

--- a/src/LoadingStoreValue.ts
+++ b/src/LoadingStoreValue.ts
@@ -59,7 +59,16 @@ class LoadingStoreValue implements Resource {
 
         // Proxy to all other unknown properties: return a function that yields another LoadingStoreValue
         const loadProperty = loadResource.then(resource => resource[prop])
-        const result = templateParams => new LoadingStoreValue(loadProperty.then(property => property(templateParams)._meta.load))
+
+        const result = templateParams => new LoadingStoreValue(loadProperty.then(property => {
+          try {
+            return property(templateParams)._meta.load
+          } catch (e) {
+            throw new Error(`Property '${prop.toString()}' on resource ${absoluteSelf} was used like a relation, but no relation with this name was returned by the API (actual return value: ${JSON.stringify(property)})`)
+          }
+        }
+        ))
+
         result.toString = () => ''
         return result
       }

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1486,7 +1486,7 @@ describe('API store', () => {
         done()
       })
 
-      it('throws error when accessing primite property like a relation', async done => {
+      it('throws error when accessing primitive property like a relation', async done => {
         // given
         axiosMock.onGet('http://localhost/').reply(200, root.serverResponse)
 

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1467,6 +1467,42 @@ describe('API store', () => {
         expect(vm.api.get('/camps/1').emptyArray).toEqual([])
         done()
       })
+
+      it('throws error when accessing non-existing property like a relation', async done => {
+        // given
+        axiosMock.onGet('http://localhost/').reply(200, root.serverResponse)
+
+        // when
+        let loadingObject = null
+        loadingObject = vm.api.get().nonexistingProperty()
+
+        // then (loading)
+        expect(loadingObject).toBeInstanceOf(LoadingStoreValue)
+        expect(loadingObject.toJSON()).toEqual('{}')
+
+        // then (loaded)
+        await expect(loadingObject._meta.load).rejects.toThrow("Property 'nonexistingProperty' on resource http://localhost was used like a relation, but no relation with this name was returned by the API (actual return value: undefined)")
+
+        done()
+      })
+
+      it('throws error when accessing primite property like a relation', async done => {
+        // given
+        axiosMock.onGet('http://localhost/').reply(200, root.serverResponse)
+
+        // when
+        let loadingObject = null
+        loadingObject = vm.api.get().the()
+
+        // then (loading)
+        expect(loadingObject).toBeInstanceOf(LoadingStoreValue)
+        expect(loadingObject.toJSON()).toEqual('{}')
+
+        // then (loaded)
+        await expect(loadingObject._meta.load).rejects.toThrow("Property 'the' on resource http://localhost was used like a relation, but no relation with this name was returned by the API (actual return value: \"root\")")
+
+        done()
+      })
     })
   })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
-var path = require('path')
-var webpack = require('webpack')
-var nodeExternals = require('webpack-node-externals')
+const path = require('path')
+const webpack = require('webpack')
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
   devtool: 'source-map',
@@ -16,7 +16,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production')
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
       }
     })
   ],


### PR DESCRIPTION
Contributes to #54 

Improves the error message if a primitive property or a non-existing property is used like a relation.

Previously this threw something like
```
t2 is not a function
```