### PR TITLE
Request interceptors

### DIFF
--- a/src/LoadingResource.ts
+++ b/src/LoadingResource.ts
@@ -64,9 +64,9 @@ class LoadingResource implements ResourceInterface {
         // Proxy to all other unknown properties: return a function that yields another LoadingResource
         const loadProperty = loadResource.then(resource => resource[prop])
 
-        const result = templateParams => new LoadingResource(loadProperty.then(property => {
+        const result = (templateParams, options) => new LoadingResource(loadProperty.then(property => {
           try {
-            return property(templateParams)._meta.load
+            return property(templateParams, options)._meta.load
           } catch (e) {
             throw new Error(`Property '${prop.toString()}' on resource '${self}' was used like a relation, but no relation with this name was returned by the API (actual return value: ${JSON.stringify(property)})`)
           }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -45,11 +45,11 @@ class Resource implements ResourceInterface {
 
           // storeData[key] is a reference only (contains only href; no data)
         } else if (isEntityReference(value)) {
-          this[key] = () => this.apiActions.get(value.href)
+          this[key] = (_, options) => this.apiActions.get(value.href, options)
 
           // storeData[key] is a templated link
         } else if (isTemplatedLink(value)) {
-          this[key] = templateParams => this.apiActions.get(urltemplate.parse(value.href).expand(templateParams || {}))
+          this[key] = (templateParams, options) => this.apiActions.get(urltemplate.parse(value.href).expand(templateParams || {}), options)
 
           // storeData[key] is a primitive (normal entity property)
         } else {

--- a/src/interfaces/ApiActions.ts
+++ b/src/interfaces/ApiActions.ts
@@ -1,7 +1,8 @@
 import ResourceInterface from './ResourceInterface'
+import Options from './Options'
 
 interface ApiActions {
-    get: (uriOrEntity: string | ResourceInterface) => ResourceInterface
+    get: (uriOrEntity: string | ResourceInterface, options?: Options) => ResourceInterface
     reload: (uriOrEntity: string | ResourceInterface) => Promise<ResourceInterface>
     post: (uriOrEntity: string | ResourceInterface, data: unknown) => Promise<ResourceInterface | null>
     patch: (uriOrEntity: string | ResourceInterface, data: unknown) => Promise<ResourceInterface>

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -1,0 +1,7 @@
+import { AxiosRequestConfig } from 'axios'
+
+interface Options {
+    axiosRequestInterceptor?: (config: AxiosRequestConfig) => AxiosRequestConfig
+}
+
+export default Options


### PR DESCRIPTION
Goal for now is to use these for specifying custom serialization groups: https://api-platform.com/docs/core/filters/#serializer-filters

This could help with over- and under-fetching problems in the frontend and in the print services.

For now, I only implemented this for GET requests. If it works out well, we could also add it to POST, PATCH and even DELETE.