### PR TITLE
RFC: Add advanced typing to your hal json vuex

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:vue/recommended",
-    "@vue/standard"
+    "@vue/standard",
+    "prettier"
   ],
   "overrides": [
     {
@@ -28,7 +29,9 @@
       ],
       "rules": {
         "no-redeclare": "off",
-        "@typescript-eslint/no-redeclare": ["error"]
+        "@typescript-eslint/no-redeclare": ["error"],
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-use-before-define": "error"
       }
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "ts-loader": "9.2.6",
         "typescript": "4.5.5",
         "vite": "4.4.4",
+        "vite-plugin-dts": "^3.6.3",
         "vue": "3.3.6",
         "vuex": "4.1.0"
       },
@@ -2864,6 +2865,117 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.38.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.38.2.tgz",
+      "integrity": "sha512-JOARuhTwOcOMIU0O2czscoJy3ddVzIRhSA9/7T1ALuZSNphgWsPk+Bv4E7AnBDmTV4pP4lBNLtCxEHjjpWaytQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.28.2",
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.61.0",
+        "@rushstack/rig-package": "0.5.1",
+        "@rushstack/ts-command-line": "4.17.1",
+        "colors": "~1.2.1",
+        "lodash": "~4.17.15",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "source-map": "~0.6.1",
+        "typescript": "~5.0.4"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.2.tgz",
+      "integrity": "sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.61.0"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2904,6 +3016,129 @@
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "3.61.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.61.0.tgz",
+      "integrity": "sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
+      "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "~1.22.1",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz",
+      "integrity": "sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==",
+      "dev": true,
+      "dependencies": {
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "colors": "~1.2.1",
+        "string-argv": "~0.3.1"
+      }
     },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -2985,6 +3220,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
@@ -3064,8 +3305,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
       "integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.8",
@@ -3450,6 +3690,34 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.10.tgz",
+      "integrity": "sha512-nsV1o3AZ5n5jaEAObrS3MWLBWaGwUj/vAsc15FVNIv+DbpizQRISg9wzygsHBr56ELRH8r4K75vkYNMtsSNNWw==",
+      "dev": true,
+      "dependencies": {
+        "@volar/source-map": "1.10.10"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.10.tgz",
+      "integrity": "sha512-GVKjLnifV4voJ9F0vhP56p4+F3WGf+gXlRtjFZsv6v3WxBTWU3ZVeaRaEHJmWrcv5LXmoYYpk/SC25BKemPRkg==",
+      "dev": true,
+      "dependencies": {
+        "muggle-string": "^0.3.1"
+      }
+    },
+    "node_modules/@volar/typescript": {
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.10.tgz",
+      "integrity": "sha512-4a2r5bdUub2m+mYVnLu2wt59fuoYWe7nf0uXtGHU8QQ5LDNfzAR0wK7NgDiQ9rcl2WT3fxT2AA9AylAwFtj50A==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.10.10",
+        "path-browserify": "^1.0.1"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.6.tgz",
@@ -3528,6 +3796,54 @@
         "@vue/cli-service": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.22.tgz",
+      "integrity": "sha512-bsMoJzCrXZqGsxawtUea1cLjUT9dZnDsy5TuZ+l1fxRMzUGQUG9+Ypq4w//CqpWmrx7nIAJpw2JVF/t258miRw==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "~1.10.5",
+        "@volar/source-map": "~1.10.5",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -5046,6 +5362,15 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5071,6 +5396,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -5242,6 +5573,12 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true
     },
     "node_modules/debug": {
@@ -7717,6 +8054,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hosted-git-info": {
@@ -10581,6 +10927,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "node_modules/js-beautify": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
@@ -10801,6 +11153,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true
     },
     "node_modules/latest-version": {
       "version": "5.1.0",
@@ -11136,6 +11494,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.isequal": {
@@ -11577,6 +11941,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/muggle-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "node_modules/mute-stream": {
@@ -12644,6 +13014,12 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -13703,6 +14079,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -15012,6 +15397,15 @@
         "builtins": "^1.0.3"
       }
     },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vite": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.4.tgz",
@@ -15063,6 +15457,32 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.6.3.tgz",
+      "integrity": "sha512-NyRvgobl15rYj65coi/gH7UAEH+CpSjh539DbGb40DfOTZSvDLNYTzc8CK4460W+LqXuMK7+U3JAxRB3ksrNPw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/api-extractor": "^7.38.0",
+        "@rollup/pluginutils": "^5.0.5",
+        "@vue/language-core": "^1.8.20",
+        "debug": "^4.3.4",
+        "kolorist": "^1.8.0",
+        "vue-tsc": "^1.8.20"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }
@@ -15193,6 +15613,66 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+      "dev": true,
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.22.tgz",
+      "integrity": "sha512-j9P4kHtW6eEE08aS5McFZE/ivmipXy0JzrnTgbomfABMaVKx37kNBw//irL3+LlE3kOo63XpnRigyPC3w7+z+A==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "~1.10.5",
+        "@vue/language-core": "1.8.22",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/vuex": {
       "version": "4.1.0",
@@ -15652,6 +16132,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "homepage": "https://github.com/ecamp/hal-json-vuex#readme",
   "dependencies": {
     "hal-json-normalizer": "^4.2.0",
+    "prettier": "^3.0.3",
     "url-template": "^2.0.8"
   },
   "devDependencies": {
@@ -61,18 +62,17 @@
     "@babel/preset-env": "7.16.11",
     "@babel/preset-typescript": "7.16.7",
     "@types/jest": "27.5.1",
-    "@typescript-eslint/eslint-plugin": "5.10.1",
-    "@typescript-eslint/parser": "5.10.1",
-    "@vue/eslint-config-standard": "6.1.0",
+    "@typescript-eslint/eslint-plugin": "6.9.1",
+    "@typescript-eslint/parser": "6.9.1",
+    "@vue/compiler-sfc": "3.3.6",
+    "@vue/eslint-config-standard": "8.0.1",
     "@vue/test-utils": "2.4.1",
     "axios": "0.25.0",
     "axios-mock-adapter": "1.20.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "27.5.1",
-    "babel-loader": "8.2.3",
     "cross-env": "7.0.3",
     "eslint": "7.32.0",
-    "eslint-loader": "4.0.2",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
@@ -81,15 +81,12 @@
     "jest": "27.5.1",
     "lodash": "4.17.21",
     "mock-xmlhttprequest": "8.1.0",
-    "np": "7.6.3",
     "rimraf": "3.0.2",
-    "source-map-loader": "3.0.1",
     "ts-jest": "27.1.3",
-    "ts-loader": "9.2.6",
-    "typescript": "4.5.5",
+    "typescript": "5.2.2",
     "vite": "4.4.4",
+    "vite-plugin-dts": "^3.6.3",
     "vue": "3.3.6",
-    "@vue/compiler-sfc": "3.3.6",
     "vuex": "4.1.0"
   }
 }

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -8,45 +8,45 @@ import Resource from './Resource'
 /**
   * Filter out items that are marked as deleting (eager removal)
   */
-function filterDeleting (array: Array<ResourceInterface>): Array<ResourceInterface> {
+function filterDeleting<T extends ResourceInterface> (array: Array<T>): Array<T> {
   return array.filter(entry => !entry._meta.deleting)
 }
 
-class Collection extends Resource {
+class Collection<Item extends ResourceInterface> extends Resource<Item & Link> implements CollectionInterface<Item>{
   /**
      * Get items excluding ones marked as 'deleting' (eager remove)
      * The items property should always be a getter, in order to make the call to mapArrayOfEntityReferences
      * lazy, since that potentially fetches a large number of entities from the API.
      */
-  public get items (): Array<ResourceInterface> {
-    return filterDeleting(this._mapArrayOfEntityReferences(this._storeData.items))
+  public get items (): Array<Item> {
+    return filterDeleting<Item>(this._mapArrayOfEntityReferences(this._storeData.items))
   }
 
   /**
      * Get all items including ones marked as 'deleting' (lazy remove)
      */
-  public get allItems (): Array<ResourceInterface> {
+  public get allItems (): Array<Item> {
     return this._mapArrayOfEntityReferences(this._storeData.items)
   }
 
   /**
      * Returns a promise that resolves to the collection object, once all items have been loaded
      */
-  public $loadItems () :Promise<CollectionInterface> {
+  public $loadItems () :Promise<CollectionInterface<Item>> {
     return this._itemLoader(this._storeData.items)
   }
 
   /**
      *  Returns a promise that resolves to the collection object, once all items have been loaded
      */
-  private _itemLoader (array: Array<Link>) : Promise<CollectionInterface> {
+  private _itemLoader (array: Array<Item & Link>) : Promise<CollectionInterface<Item>> {
     if (!this._containsUnknownEntityReference(array)) {
-      return Promise.resolve(this as unknown as CollectionInterface) // we know that this object must be of type CollectionInterface
+      return Promise.resolve(this as unknown as CollectionInterface<Item>) // we know that this object must be of type CollectionInterface
     }
 
     // eager loading of 'fetchAllUri' (e.g. parent for embedded collections)
     if (this.config.avoidNPlusOneRequests) {
-      return this.apiActions.reload(this as unknown as CollectionInterface) as Promise<CollectionInterface> // we know that reload resolves to a type CollectionInterface
+      return this.apiActions.reload(this as unknown as CollectionInterface<Item>) as Promise<CollectionInterface<Item>> // we know that reload resolves to a type CollectionInterface
 
       // no eager loading: replace each reference (Link) with a Resource (ResourceInterface)
     } else {
@@ -54,7 +54,7 @@ class Collection extends Resource {
 
       return Promise.all(
         arrayWithReplacedReferences.map(entry => entry._meta.load)
-      ).then(() => this as unknown as CollectionInterface) // we know that this object must be of type CollectionInterface
+      ).then(() => this as unknown as CollectionInterface<Item>) // we know that this object must be of type CollectionInterface
     }
   }
 
@@ -68,7 +68,7 @@ class Collection extends Resource {
      * @returns array          the new array with replaced items, or a LoadingCollection if any of the array
      *                         elements is still loading.
      */
-  private _mapArrayOfEntityReferences (array: Array<Link>): Array<ResourceInterface> {
+  private _mapArrayOfEntityReferences (array: Array<Item & Link>): Array<Item> {
     if (!this._containsUnknownEntityReference(array)) {
       return this._replaceEntityReferences(array)
     }
@@ -77,27 +77,27 @@ class Collection extends Resource {
 
     // eager loading of 'fetchAllUri' (e.g. parent for embedded collections)
     if (this.config.avoidNPlusOneRequests) {
-      return LoadingCollection.create(itemsLoaded)
+      return LoadingCollection.create<Item>(itemsLoaded)
 
       // no eager loading: replace each reference (Link) with a Resource (ResourceInterface)
     } else {
-      return LoadingCollection.create(itemsLoaded, this._replaceEntityReferences(array))
+      return LoadingCollection.create<Item>(itemsLoaded, this._replaceEntityReferences(array))
     }
   }
 
   /**
    * Replace each item in array with a proper Resource (or LoadingResource)
    */
-  private _replaceEntityReferences (array: Array<Link>): Array<ResourceInterface> {
+  private _replaceEntityReferences (array: Array<Item & Link>): Array<Item> {
     return array
       .filter(entry => isEntityReference(entry))
-      .map(entry => this.apiActions.get(entry.href))
+      .map(entry => this.apiActions.get<Item>(entry.href))
   }
 
   /**
    * Returns true if any of the items within 'array' is not yet known to the API (meaning it has never been loaded)
    */
-  private _containsUnknownEntityReference (array: Array<Link>): boolean {
+  private _containsUnknownEntityReference (array: Array<Item & Link>): boolean {
     return array.some(entry => isEntityReference(entry) && this.apiActions.isUnknown(entry.href))
   }
 }

--- a/src/LoadingCollection.ts
+++ b/src/LoadingCollection.ts
@@ -9,7 +9,7 @@ class LoadingCollection {
    * @param loadArray       Promise that resolves once the array has finished loading
    * @param existingContent optionally set the elements that are already known, for random access
    */
-  static create (loadArray: Promise<Array<ResourceInterface> | undefined>, existingContent: Array<ResourceInterface> = []): Array<ResourceInterface> {
+  static create<T extends ResourceInterface<any>> (loadArray: Promise<Array<T> | undefined>, existingContent: Array<T> = []): T[] {
     // if Promsise resolves to undefined, provide empty array
     // this could happen if items is accessed from a LoadingResource, which resolves to a normal entity without 'items'
     const loadArraySafely = loadArray.then(array => array ?? [])
@@ -19,7 +19,7 @@ class LoadingCollection {
     singleResultFunctions.forEach(func => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       existingContent[func] = (...args: any[]) => {
-        const resultLoaded = loadArraySafely.then(array => array[func](...args) as ResourceInterface)
+        const resultLoaded = loadArraySafely.then(array => array[func](...args) as T)
         return new LoadingResource(resultLoaded)
       }
     })
@@ -29,7 +29,7 @@ class LoadingCollection {
     arrayResultFunctions.forEach(func => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       existingContent[func] = (...args: any[]) => {
-        const resultLoaded = loadArraySafely.then(array => array[func](...args) as Array<ResourceInterface>) // TODO: return type for .map() is not necessarily an Array<ResourceInterface>
+        const resultLoaded = loadArraySafely.then(array => array[func](...args) as Array<T>) // TODO: return type for .map() is not necessarily an Array<ResourceInterface>
         return LoadingCollection.create(resultLoaded)
       }
     })

--- a/src/LoadingResource.ts
+++ b/src/LoadingResource.ts
@@ -15,15 +15,15 @@ import { InternalConfig } from './interfaces/Config'
  * let user = new LoadingResource(...)
  * 'The "' + user + '" is called "' + user.name + '"' // gives 'The "" is called ""'
  */
-class LoadingResource implements ResourceInterface {
+class LoadingResource<T extends ResourceInterface<T>, Item extends ResourceInterface> implements ResourceInterface<T> {
   public _meta: {
     self: string | null,
     selfUrl: string | null,
-    load: Promise<ResourceInterface>
+    load: Promise<T>
     loading: boolean
   }
 
-  private loadResource: Promise<ResourceInterface>
+  private loadResource: Promise<T>
 
   /**
    * @param loadResource a Promise that resolves to a Resource when the entity has finished
@@ -32,9 +32,9 @@ class LoadingResource implements ResourceInterface {
    *                     returned LoadingResource will return it in calls to .self and ._meta.self
    * @param config       configuration of this instance of hal-json-vuex
    */
-  constructor (loadResource: Promise<ResourceInterface>, self: string | null = null, config: InternalConfig | null = null) {
+  constructor (loadResource: Promise<T>, self: string | null = null, config: InternalConfig | null = null) {
     this._meta = {
-      self: self,
+      self,
       selfUrl: self ? config?.apiRoot + self : null,
       load: loadResource,
       loading: true
@@ -43,7 +43,7 @@ class LoadingResource implements ResourceInterface {
     this.loadResource = loadResource
 
     const handler = {
-      get: function (target: LoadingResource, prop: string | number | symbol) {
+      get: function (target: LoadingResource<T, Item>, prop: string | number | symbol) {
         // This is necessary so that Vue's reactivity system understands to treat this LoadingResource
         // like a normal object.
         if (prop === Symbol.toPrimitive) {
@@ -80,28 +80,28 @@ class LoadingResource implements ResourceInterface {
     return new Proxy(this, handler)
   }
 
-  get items (): Array<ResourceInterface> {
-    return LoadingCollection.create(this.loadResource.then(resource => (resource as CollectionInterface).items))
+  get items (): Array<Item> {
+    return LoadingCollection.create<Item>(this.loadResource.then(resource => (resource as unknown as CollectionInterface<Item>).items))
   }
 
-  get allItems (): Array<ResourceInterface> {
-    return LoadingCollection.create(this.loadResource.then(resource => (resource as CollectionInterface).allItems))
+  get allItems (): Array<Item> {
+    return LoadingCollection.create<Item>(this.loadResource.then(resource => (resource as unknown as CollectionInterface<Item>).allItems))
   }
 
-  public $reload (): Promise<ResourceInterface> {
+  public $reload (): Promise<T> {
     // Skip reloading entities that are already loading
     return this._meta.load
   }
 
-  public $loadItems (): Promise<CollectionInterface> {
-    return this._meta.load.then(resource => (resource as CollectionInterface).$loadItems())
+  public $loadItems (): Promise<CollectionInterface<Item>> {
+    return this._meta.load.then(resource => (resource as unknown as CollectionInterface<Item>).$loadItems())
   }
 
-  public $post (data: unknown): Promise<ResourceInterface | null> {
+  public $post (data: unknown): Promise<T | null> {
     return this._meta.load.then(resource => resource.$post(data))
   }
 
-  public $patch (data: unknown): Promise<ResourceInterface> {
+  public $patch (data: unknown): Promise<T> {
     return this._meta.load.then(resource => resource.$patch(data))
   }
 

--- a/src/halHelpers.ts
+++ b/src/halHelpers.ts
@@ -1,7 +1,9 @@
-import { Link, VirtualLink, TemplatedLink, StoreDataCollection } from './interfaces/StoreData'
+import { Link, VirtualLink, TemplatedLink } from './interfaces/StoreData'
 import { ResourceInterface, VirtualResource } from './interfaces/ResourceInterface'
+import Collection from '@/Collection'
+import CollectionInterface from "@/interfaces/CollectionInterface";
 
-type keyValueObject = Record<string, unknown>
+export type keyValueObject = Record<string, unknown>
 
 /**
  * Verifies that two arrays contain the same values while ignoring the order
@@ -26,7 +28,7 @@ function isTemplatedLink (object: keyValueObject): object is TemplatedLink {
  * @param object    to be examined
  * @returns boolean true if the object looks like an entity reference, false otherwise
  */
-function isEntityReference (object: keyValueObject): object is Link {
+function isEntityReference (object: unknown): object is Link {
   if (!object) return false
   return isEqualIgnoringOrder(Object.keys(object), ['href'])
 }
@@ -47,7 +49,7 @@ function isVirtualLink (object: keyValueObject): object is VirtualLink {
  * @param resource
  * @returns boolean  true if resource is a VirtualResource
  */
-function isVirtualResource (resource: ResourceInterface): resource is VirtualResource {
+function isVirtualResource (resource: unknown): resource is VirtualResource {
   return (resource as VirtualResource)._storeData?._meta?.virtual
 }
 
@@ -56,8 +58,8 @@ function isVirtualResource (resource: ResourceInterface): resource is VirtualRes
  * @param object    to be examined
  * @returns boolean true if the object looks like a standalone collection, false otherwise
  */
-function isCollection (object: keyValueObject): object is StoreDataCollection {
-  return !!(object && Array.isArray(object.items))
+function isCollection<Item extends ResourceInterface> (object: unknown): object is CollectionInterface<Item> {
+  return !!(object && Array.isArray((object as CollectionInterface<Item>).items))
 }
 
 export { isTemplatedLink, isVirtualLink, isEntityReference, isCollection, isVirtualResource }

--- a/src/interfaces/ApiActions.ts
+++ b/src/interfaces/ApiActions.ts
@@ -1,12 +1,19 @@
 import ResourceInterface from './ResourceInterface'
 
+type ApiActionGet =  <Type extends ResourceInterface>(uriOrEntity?: string | Type) => Type
+type ApiActionReload = <Type extends ResourceInterface>(uriOrEntity: string | Type) => Promise<Type>
+type ApiActionPost = <Type extends ResourceInterface>(uriOrEntity: string | Type, data: unknown) => Promise<Type | null>
+type ApiActionPatch = <Type extends ResourceInterface>(uriOrEntity: string | Type, data: unknown) => Promise<Type>
+type ApiActionDel = <Type extends ResourceInterface>(uriOrEntity: string | Type) => Promise<string | void>
+type ApiActionHref = <Type extends ResourceInterface>(uriOrEntity: string | Type, relation: string, templateParams) => Promise<string | undefined>
+
 interface ApiActions {
-    get: (uriOrEntity: string | ResourceInterface) => ResourceInterface
-    reload: (uriOrEntity: string | ResourceInterface) => Promise<ResourceInterface>
-    post: (uriOrEntity: string | ResourceInterface, data: unknown) => Promise<ResourceInterface | null>
-    patch: (uriOrEntity: string | ResourceInterface, data: unknown) => Promise<ResourceInterface>
-    del: (uriOrEntity: string | ResourceInterface) => Promise<string | void>
-    href: (uriOrEntity: string | ResourceInterface, relation: string, templateParams) => Promise<string | undefined>
+    get: ApiActionGet
+    reload: ApiActionReload
+    post: ApiActionPost
+    patch: ApiActionPatch
+    del: ApiActionDel
+    href: ApiActionHref
     isUnknown: (uri: string) => boolean
 }
 

--- a/src/interfaces/CollectionInterface.ts
+++ b/src/interfaces/CollectionInterface.ts
@@ -1,12 +1,10 @@
 import ResourceInterface from './ResourceInterface'
-import { StoreDataCollection } from './StoreData'
+import { Link, StoreData } from './StoreData'
 
-interface CollectionInterface extends ResourceInterface {
-    _storeData: StoreDataCollection
-
-    items: Array<ResourceInterface>
-    allItems: Array<ResourceInterface>
-    $loadItems: () => Promise<CollectionInterface>
+interface CollectionInterface<T extends ResourceInterface = ResourceInterface> extends ResourceInterface<CollectionInterface<T> & Link> {
+    items: Array<T>
+    allItems: Array<T>
+    $loadItems: () => Promise<CollectionInterface<T>>
 }
 
 export default CollectionInterface

--- a/src/interfaces/ResourceInterface.ts
+++ b/src/interfaces/ResourceInterface.ts
@@ -4,26 +4,26 @@ import { StoreData, VirtualStoreData } from './StoreData'
  * Generic interface for a standalone ResourceInterface (e.g. a HAl resource with an own store entry and a self link)
  * Can be a collection or a single entity
  */
-interface ResourceInterface {
+interface ResourceInterface<T extends ResourceInterface<any> = ResourceInterface<any>> {
     _meta: {
         self: string | null
         selfUrl: string | null
-        load: Promise<ResourceInterface>
+        load: Promise<T>
         loading: boolean
         deleting?: boolean
     }
 
-    _storeData?: StoreData // optional, because LoadingResource has no _storeData
+    _storeData?: StoreData<T> // optional, because LoadingResource has no _storeData
 
-    $reload: () => Promise<ResourceInterface>
-    $post: (data: unknown) => Promise<ResourceInterface | null>
-    $patch: (data: unknown) => Promise<ResourceInterface>
+    $reload: () => Promise<T>
+    $post: (data: unknown) => Promise<T | null>
+    $patch: (data: unknown) => Promise<T>
     $del: () => Promise<string | void>
     $href: (relation: string, templateParams: Record<string, string | number | boolean>) => Promise<string | undefined>
 }
 
-interface VirtualResource extends ResourceInterface {
-    _storeData: VirtualStoreData
+interface VirtualResource<T extends ResourceInterface<any> = ResourceInterface<any>> extends ResourceInterface<T> {
+    _storeData: VirtualStoreData<T>
 }
 
 export { ResourceInterface, VirtualResource }

--- a/src/interfaces/StoreData.ts
+++ b/src/interfaces/StoreData.ts
@@ -31,23 +31,23 @@ type VirtualStoreDataMeta = StoreDataMeta & {
     }
 }
 
-type StoreDataEntity = StoreDataMeta & {
-    items: never,
+type StoreDataEntity<T> = StoreDataMeta & {
+    items: T[],
     _meta: {
-        load: SerializablePromise<StoreDataEntity>
+        load: SerializablePromise<StoreDataEntity<T>>
     }
 }
 
-type StoreDataCollection = StoreDataMeta & {
-    items: Array<Link>,
+type StoreDataCollection<Item extends Link> = StoreDataMeta & {
+    items: Array<Item & Link>,
     _meta: {
-        load: SerializablePromise<StoreDataCollection>
+        load: SerializablePromise<StoreDataCollection<Item & Link>>
     }
 }
 
-type StoreData = StoreDataEntity | StoreDataCollection
+type StoreData<T> = StoreDataEntity<T> | StoreDataCollection<T & Link>
 
-type VirtualStoreData = StoreData & VirtualStoreDataMeta
+type VirtualStoreData<T> = StoreData<T> & VirtualStoreDataMeta
 
 export { StoreData, VirtualStoreData, Link, VirtualLink, TemplatedLink, StoreDataEntity, StoreDataCollection, SerializablePromise }
 

--- a/src/interfaces/StoreData.ts
+++ b/src/interfaces/StoreData.ts
@@ -32,20 +32,19 @@ type VirtualStoreDataMeta = StoreDataMeta & {
 }
 
 type StoreDataEntity<T> = StoreDataMeta & {
-    items: T[],
     _meta: {
         load: SerializablePromise<StoreDataEntity<T>>
     }
-}
+} & T
 
-type StoreDataCollection<Item extends Link> = StoreDataMeta & {
-    items: Array<Item & Link>,
+type StoreDataCollection<T> = StoreDataMeta & {
+    items: Array<Link>,
     _meta: {
-        load: SerializablePromise<StoreDataCollection<Item & Link>>
+        load: SerializablePromise<StoreDataCollection<T>>
     }
-}
+} & T
 
-type StoreData<T> = StoreDataEntity<T> | StoreDataCollection<T & Link>
+type StoreData<T> = StoreDataEntity<T> | StoreDataCollection<T>
 
 type VirtualStoreData<T> = StoreData<T> & VirtualStoreDataMeta
 

--- a/src/normalizeEntityUri.ts
+++ b/src/normalizeEntityUri.ts
@@ -35,7 +35,7 @@ function sortQueryParams (uri: string): string {
  * @param baseUrl         common URI prefix to remove during normalization
  * @returns {null|string} normalized URI, or null if the uriOrEntity argument was not understood
  */
-function normalizeEntityUri (uriOrEntity: string | ResourceInterface | null = '', baseUrl = ''): string | null {
+function normalizeEntityUri<T extends ResourceInterface> (uriOrEntity: string | T | null = '', baseUrl = ''): string | null {
   let uri
 
   if (typeof uriOrEntity === 'string') {

--- a/tests/testtypes.ts
+++ b/tests/testtypes.ts
@@ -430,7 +430,13 @@ root.camps({ isPrototype: false})._meta.load.then(endpoint => {
   })
 })
 
+halJsonVuex.reload<ActivityEntity>('/entity/1').then(activity => {
+    console.log(activity.title)
+})
+
 root.camps().items[0].name = "";
+
+root.camps().items[0]._storeData?._meta.load.toJSON?.();
 
 //root.camps({ isPrototype: true }).sds[0].name = "";
 root.camps({ isPrototype: true }).items[0].name = "";

--- a/tests/testtypes.ts
+++ b/tests/testtypes.ts
@@ -1,0 +1,441 @@
+import HalJsonVuex from "../src";
+import ResourceInterface from "../src/interfaces/ResourceInterface";
+import { createStore } from "vuex";
+import axios from "axios";
+import { State } from "../src/storeModule";
+import CollectionInterface from "../src/interfaces/CollectionInterface";
+
+export type ResourceType<T extends ResourceInterface<T>> = (
+  uriOrEntity?: string | T,
+) => T;
+
+export type CollectionType<
+  Item extends ResourceInterface<Item>,
+  Self extends ResourceInterface<Self> = ResourceInterface<never>,
+> = CollectionInterface<Item> & Self;
+
+const store = createStore<Record<string, State>>({});
+
+const halJsonVuex = HalJsonVuex(store, axios, {
+  forceRequestedSelfLink: true,
+});
+
+interface UserEntity extends ResourceInterface<UserEntity> {
+  id: string;
+  displayName: string;
+
+  profile: ResourceType<ProfileEntity>;
+}
+
+interface ProfileEntity extends ResourceInterface<ProfileEntity> {
+  id: string;
+  firstname: string;
+  surname: string;
+  nickname: string;
+  legalName: string;
+
+  email: string;
+
+  language: string;
+
+  user: ResourceType<UserEntity>;
+}
+
+interface CampEntity extends ResourceInterface<CampEntity> {
+  id: string;
+  name: string;
+  title: string;
+  motto: string;
+
+  isPrototype: boolean;
+  creator: ResourceType<UserEntity>;
+
+  addressName: string | null;
+  addressStreet: string | null;
+  addressZipcode: string | null;
+  addressCity: string | null;
+
+  coachName: string | null;
+  courseKind: string | null;
+  courseNumber: string | null;
+  organizer: string | null;
+  kind: string | null;
+  printYSLogoOnPicasso: boolean | null;
+  trainingAdvisorName: string | null;
+
+  activities: () => CollectionType<ActivityEntity>;
+  periods: () => CollectionType<PeriodEntity>;
+  categories: () => CollectionType<CategoryEntity>;
+  profiles: () => CollectionType<ProfileEntity>;
+  progressLabels: () => CollectionType<ActivityProgressLabelEntity>;
+}
+
+interface PeriodEntity extends ResourceInterface<PeriodEntity> {
+  id: string;
+  start: string;
+  end: string;
+
+  camp: ResourceType<CampEntity>;
+}
+
+interface ActivityEntity extends ResourceInterface<ActivityEntity> {
+  id: string;
+  title: string;
+  location: string;
+
+  camp: ResourceType<CampEntity>;
+  category: ResourceType<CategoryEntity>;
+  period: ResourceType<PeriodEntity>;
+  scheduleEntries: () => CollectionType<ScheduleEntryEntity>;
+  activityResponsibles: () => CollectionType<ActivityResponsibleEntity>;
+  activityProgressLabel: () => ResourceType<ActivityProgressLabelEntity>;
+}
+
+interface ActivityProgressLabelEntity
+  extends ResourceInterface<ActivityProgressLabelEntity> {
+  id: string;
+  title: string;
+  position: number;
+  camp: ResourceType<CampEntity>;
+}
+
+interface ActivityResponsibleEntity
+  extends ResourceInterface<ActivityResponsibleEntity> {
+  id: string;
+  activity: ResourceType<ActivityEntity>;
+  campCollaboration: ResourceType<CampCollaborationEntity>;
+}
+
+interface ScheduleEntryEntity extends ResourceInterface<ScheduleEntryEntity> {
+  id: string;
+  start: string;
+  end: string;
+
+  dayNumber: number;
+  scheduleEntryNumber: number;
+  number: string;
+
+  left: number;
+  width: number;
+
+  period: ResourceType<PeriodEntity>;
+  day: ResourceType<DayEntity>;
+}
+
+interface DayEntity extends ResourceInterface<DayEntity> {
+  id: string;
+  start: string;
+  end: string;
+
+  number: number;
+  dayOffset: number;
+
+  period: ResourceType<PeriodEntity>;
+  scheduleEntries: () => CollectionType<ScheduleEntryEntity>;
+  dayResponsibles: () => CollectionType<DayResponsibleEntity>;
+}
+
+interface DayResponsibleEntity extends ResourceInterface<DayResponsibleEntity> {
+  id: string;
+  day: ResourceType<DayEntity>;
+  campCollaboration: () => ResourceType<CampCollaborationEntity>;
+}
+
+interface CategoryEntity extends ResourceInterface<CategoryEntity> {
+  id: string;
+  short: string;
+  name: string;
+
+  numberingStyle: "a" | "A" | "i" | "I" | "1";
+  color: string;
+
+  camp: ResourceType<CampEntity>;
+  contentNodes: () => CollectionType<ContentNode>;
+  rootContentNode: ResourceType<ContentNode>;
+  preferredContentNodes: () => CollectionType<ContentNode>;
+}
+
+type ContentNode =
+  | ColumnLayoutNodeEntity
+  | MultiSelectNodeEntity
+  | SingleTextNodeEntity
+  | StoryboardNodeEntity;
+
+interface ContentNodesBase<Data = unknown> {
+  id: string;
+  contentTypeName: string;
+  instanceName: string | null;
+  slot: string;
+  position: number;
+  data: Data;
+
+  contentType: ResourceType<ContentTypeEntity>;
+
+  children: () => CollectionType<ContentNode>;
+  parent: ResourceType<ContentNode>;
+  root: ResourceType<ContentNode>;
+}
+
+interface ColumnLayoutNodeData {
+  columns: {
+    slot: string;
+    width: number;
+  }[];
+}
+
+interface ColumnLayoutNodeEntity
+  extends ContentNodesBase<ColumnLayoutNodeData>,
+    ResourceInterface<ColumnLayoutNodeEntity> {}
+
+interface MultiSelectNodeData {
+  options: {
+    [key: string]: {
+      checked: boolean;
+    };
+  };
+}
+
+interface MultiSelectNodeEntity
+  extends ContentNodesBase<MultiSelectNodeData>,
+    ResourceInterface<MultiSelectNodeEntity> {}
+
+interface SingleTextNodeData {
+  html: string;
+}
+
+interface SingleTextNodeEntity
+  extends ContentNodesBase<SingleTextNodeData>,
+    ResourceInterface<SingleTextNodeEntity> {}
+
+interface StoryboardNodeData {
+  sections: {
+    [key: string]: {
+      column1: string;
+      column2Html: string;
+      column3: string;
+      position: number;
+    };
+  };
+}
+
+interface StoryboardNodeEntity
+  extends ContentNodesBase<StoryboardNodeData>,
+    ResourceInterface<StoryboardNodeEntity> {}
+
+interface MaterialNodeEntity
+  extends ContentNodesBase<null>,
+    ResourceInterface<MaterialNodeEntity> {
+  materialItems: () => CollectionType<MaterialItemEntity>;
+}
+
+interface ContentTypeEntity extends ResourceInterface<ContentTypeEntity> {
+  id: string;
+  name: string;
+
+  contentNodes: () => CollectionType<ContentNode>;
+}
+
+interface CampCollaborationEntity
+  extends ResourceInterface<CampCollaborationEntity> {
+  id: string;
+  role: "member" | "manager" | "guest";
+  status: "invited" | "established" | "inactive";
+  camp: ResourceType<CampEntity>;
+
+  inviteEmail: string | null;
+  user: ResourceType<UserEntity> | null;
+}
+
+interface MaterialListEntity extends ResourceInterface<MaterialListEntity> {
+  id: string;
+  name: string;
+
+  itemCount: number;
+  camp: ResourceType<CampEntity>;
+  campCollaboration: ResourceType<CampCollaborationEntity>;
+}
+
+interface MaterialItemBase {
+  id: string;
+  article: string;
+  quantity: number;
+  unit: string;
+  materialList: ResourceType<MaterialListEntity>;
+}
+
+type MaterialItemEntity = MaterialItemNodeEntity | MaterialItemPeriodEntity;
+
+interface MaterialItemNodeEntity
+  extends MaterialItemBase,
+    ResourceInterface<MaterialItemNodeEntity> {
+  materialNode: ResourceType<MaterialNodeEntity>;
+  period: null;
+}
+
+interface MaterialItemPeriodEntity
+  extends MaterialItemBase,
+    ResourceInterface<MaterialItemPeriodEntity> {
+  materialNode: null;
+  period: ResourceType<PeriodEntity>;
+}
+
+interface InvitationDTO extends ResourceInterface<InvitationDTO> {
+  campId: string;
+  campTitle: string;
+  userDisplayName: string | null;
+  userAlreadyInCamp: boolean | null;
+}
+
+interface InvitationDTOParams {
+  action: "find" | "accept" | "reject";
+  id: string;
+}
+
+type CampParam = { camp?: string | string[] };
+type ActivityParam = { activity?: string | string[] };
+type PeriodParam = { period?: string | string[] };
+type ActivityResponsiblesParams = ActivityParam & {
+  activity?: { camp: string | string[] };
+};
+type ActivityResponsibleParams = {
+  activityResponsibles?: ActivityParam;
+};
+type CampPrototypeQueryParam = { isPrototype: boolean };
+type ContentNodeParam = {
+  contentType?: string | string[];
+  root?: string | string[];
+  period?: string;
+};
+type CategoryParam = { categories?: string | string[] };
+type DayParam = { day?: string | string[] };
+type DayResponsibleParams = DayParam & {
+  day?: { period: string | string[] };
+};
+type MaterialListParam = { materialList?: string | string[] };
+type MaterialNodeParam = { materialNode?: string | string[] };
+type MaterialItemParams = MaterialListParam &
+  MaterialNodeParam & { period?: string };
+type ProfileParams = {
+  user: { collaborations: { camp: string | string[] } };
+};
+type TimeParam = {
+  before?: string;
+  strictly_before?: string;
+  after?: string;
+  strictly_after?: string;
+};
+type ScheduleEntryParams = PeriodParam &
+  ActivityParam & {
+    start?: TimeParam;
+    end?: TimeParam;
+  };
+
+type SingleResource<T extends ResourceInterface<T>> = (params: { id: string }) => T;
+type QueryResources<T extends ResourceInterface<T>, Param = Record<string, any>> = (
+  params?: Param,
+) => CollectionType<T>;
+
+interface RootEndpoint extends ResourceInterface<RootEndpoint> {
+  activities: QueryResources<ActivityEntity, CampParam> &
+    SingleResource<ActivityEntity>;
+
+  activityProgressLabels: QueryResources<
+    ActivityProgressLabelEntity,
+    CampParam
+  > &
+    SingleResource<ActivityProgressLabelEntity>;
+
+  activityResponsibles: QueryResources<
+    ActivityResponsibleEntity,
+    ActivityResponsiblesParams
+  > &
+    SingleResource<ActivityResponsibleEntity>;
+
+  campCollaborations: QueryResources<
+    CampCollaborationEntity,
+    CampParam & ActivityResponsibleParams
+  > &
+    SingleResource<CampCollaborationEntity>;
+
+  camps: QueryResources<CampEntity, CampPrototypeQueryParam> &
+    SingleResource<CampEntity>;
+
+  categories: QueryResources<CategoryEntity, CampParam> &
+    SingleResource<CategoryEntity>;
+
+  columnLayouts: QueryResources<ColumnLayoutNodeEntity, ContentNodeParam> &
+    SingleResource<ColumnLayoutNodeEntity>;
+
+  contentNodes: (params?: ContentNodeParam) => CollectionType<ContentNode>;
+
+  contentTypes: ((
+    params?: CategoryParam,
+  ) => CollectionType<ContentTypeEntity>) &
+    SingleResource<ContentTypeEntity>;
+
+  days: (() => CollectionType<DayEntity>) | SingleResource<DayEntity>;
+
+  dayResponsibles: QueryResources<DayResponsibleEntity, DayResponsibleParams> &
+    SingleResource<DayResponsibleEntity>;
+
+  invitations: (params: InvitationDTOParams) => InvitationDTO;
+
+  login: () => ResourceInterface<never>;
+
+  materialItems: QueryResources<MaterialItemEntity, MaterialItemParams> &
+    SingleResource<MaterialItemEntity>;
+
+  materialLists: QueryResources<MaterialListEntity, CampParam> &
+    SingleResource<MaterialListEntity>;
+
+  materialNodes: QueryResources<MaterialNodeEntity, ContentNodeParam> &
+    SingleResource<MaterialNodeEntity>;
+
+  multiSelects: QueryResources<MultiSelectNodeEntity, ContentNodeParam> &
+    SingleResource<MultiSelectNodeEntity>;
+
+  oauthCevidb: () => ResourceInterface<never>;
+
+  oauthGoogle: () => ResourceInterface<never>;
+
+  oauthJubladb: () => ResourceInterface<never>;
+
+  oauthPbsmidata: () => ResourceInterface<never>;
+
+  periods: QueryResources<PeriodEntity, CampParam> &
+    SingleResource<PeriodEntity>;
+
+  profiles: QueryResources<ProfileEntity, ProfileParams> &
+    SingleResource<ProfileEntity>;
+
+  resetPassword: () => ResourceInterface<never>;
+
+  scheduleEntries: QueryResources<ScheduleEntryEntity, ScheduleEntryParams> &
+    SingleResource<ScheduleEntryEntity>;
+
+  singleTexts: QueryResources<SingleTextNodeEntity, ContentNodeParam> &
+    SingleResource<SingleTextNodeEntity>;
+
+  storyboards: QueryResources<StoryboardNodeEntity, ContentNodeParam> &
+    SingleResource<StoryboardNodeEntity>;
+
+  users: (() => CollectionType<UserEntity>) & SingleResource<UserEntity>;
+}
+
+const root = halJsonVuex.get<RootEndpoint>();
+
+root.camps({ isPrototype: false})._meta.load.then(endpoint => {
+  const ugus = endpoint.items[0].$reload().then(camp => {
+    camp.name
+  })
+})
+
+root.camps().items[0].name = "";
+
+//root.camps({ isPrototype: true }).sds[0].name = "";
+root.camps({ isPrototype: true }).items[0].name = "";
+
+root.camps({ isPrototype: true }).items[0].name = "";
+
+const gugus = root.invitations({ action: "find", id: "123" });
+gugus.campTitle = "";

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 // vite.config.js
 
 import { defineConfig } from "vite";
+import dts from 'vite-plugin-dts'
 
 export default defineConfig({
   build: {
@@ -20,4 +21,5 @@ export default defineConfig({
       fileName: "hal-json-vuex",
     }
   },
+  plugins: [dts({ rollupTypes: true })]
 });


### PR DESCRIPTION
I tried to create a generic typing system that allows one to define the types to be used further.

In `tests/testtypes.ts` you can see the definition of the whole endpoint and below it's usage and type autocompletion/errors.

What do you think about the ability to further type methods of hal-json-vuex.

(Currently the _storeData is not exactly perfectly typed. But usually you don't use these as a library consumer)