### PR TITLE
Make v3 compatible with vue2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "hal-json-normalizer": "^4.2.0",
-        "url-template": "^3.1.1"
+        "url-template": "^3.1.1",
+        "vue-demi": "^0.14.10"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.10.1",
@@ -39,6 +40,15 @@
       },
       "engines": {
         "node": ">=16.0.0 <21.0.0"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2511,8 +2521,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -3716,8 +3725,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -5044,7 +5052,6 @@
       "version": "0.30.11",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
       "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -5191,7 +5198,6 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5431,8 +5437,7 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5450,7 +5455,6 @@
       "version": "8.4.41",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
       "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5904,7 +5908,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6372,7 +6375,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6566,7 +6568,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6933,7 +6935,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.6.tgz",
       "integrity": "sha512-jJIDETeWJnoY+gfn4ZtMPMS5KtbP4ax+CT4dcQFhTnWEk8xMupFyQ0JxL28nvT/M4+p4a0ptxaV2WY0LiIxvRg==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.3.6",
         "@vue/compiler-sfc": "3.3.6",
@@ -6955,6 +6956,31 @@
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.29.tgz",
       "integrity": "sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==",
       "dev": true
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "7.11.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   ],
   "authors": [
     "Carlo Beltrame",
-    "Urban Suppiger"
+    "Urban Suppiger",
+    "Manuel Meister"
   ],
   "license": "MIT",
   "bugs": {
@@ -56,7 +57,17 @@
   "homepage": "https://github.com/ecamp/hal-json-vuex#readme",
   "dependencies": {
     "hal-json-normalizer": "^4.2.0",
-    "url-template": "^3.1.1"
+    "url-template": "^3.1.1",
+    "vue-demi": "^0.14.10"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.0.0-rc.1",
+    "vue": "^2.0.0 || >=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@vue/composition-api": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.10.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import ResourceInterface from './interfaces/ResourceInterface'
 import StoreData, { Link, SerializablePromise } from './interfaces/StoreData'
 import ApiActions from './interfaces/ApiActions'
 import { isVirtualResource } from './halHelpers'
+import { App, isVue2, isVue3, Vue2 } from 'vue-demi'
 
 /**
  * Defines the API store methods available in all Vue components. The methods can be called as follows:
@@ -444,17 +445,19 @@ function HalJsonVuex (store: Store<Record<string, State>>, axios: AxiosInstance,
   const halJsonVuex = { ...apiActions, purge, purgeAll, href, Resource, LoadingResource }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function install (app: any) {
-    if (app.version && app.version.charAt(0) === '3') {
-      Object.defineProperties(app.config.globalProperties, {
-        [opts.apiName]: {
-          get () {
-            return halJsonVuex
-          }
-        }
+  function install (app: App | typeof Vue2) {
+    if (isVue3) {
+      Object.defineProperty(app.config.globalProperties, opts.apiName, {
+        get: () => halJsonVuex,
+        configurable: true
+      })
+    } else if (isVue2) {
+      Object.defineProperty(app.prototype, opts.apiName, {
+        get: () => halJsonVuex,
+        configurable: true
       })
     } else {
-      throw new Error('Vue2 detected: this version of hal-json-vuex is not compatible with Vue2')
+      throw new Error('Neither Vue2 or Vue3 detected')
     }
   }
 

--- a/src/storeModule.ts
+++ b/src/storeModule.ts
@@ -1,3 +1,5 @@
+import { del, set } from 'vue-demi'
+
 import StoreData from './interfaces/StoreData'
 
 import { MutationTree } from 'vuex/types'
@@ -13,9 +15,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the object that is being fetched
    */
   addEmpty (state: State, uri: string) : void {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    state[uri] = { _meta: { self: uri, loading: true } }
+    set(state, uri, { _meta: { self: uri, loading: true } })
   },
   /**
    * Adds entities loaded from the API to the Vuex store.
@@ -24,12 +24,10 @@ export const mutations: MutationTree<State> = {
    */
   add (state: State, data: Record<string, unknown>) : void {
     Object.keys(data).forEach(uri => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      state[uri] = data[uri]
+      set(state, uri, data[uri])
 
-      state[uri]._meta.loading = false
-      state[uri]._meta.reloading = false
+      set(state[uri]._meta, 'loading', false)
+      set(state[uri]._meta, 'reloading', false)
     })
   },
   /**
@@ -38,7 +36,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the entity that is currently being reloaded
    */
   reloading (state: State, uri: string) : void {
-    if (state[uri]) state[uri]._meta.reloading = true
+    if (state[uri]) set(state[uri]._meta, 'reloading', true)
   },
   /**
    * Marks a single entity in the Vuex store as normal again, after it has been marked as reloading before.
@@ -46,7 +44,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the entity that is currently being reloaded
    */
   reloadingFailed (state: State, uri: string) : void {
-    if (state[uri]) state[uri]._meta.reloading = false
+    if (state[uri]) set(state[uri]._meta, 'reloading', false)
   },
   /**
    * Removes a single entity from the Vuex store.
@@ -54,7 +52,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the entity to be removed
    */
   purge (state: State, uri: string) : void {
-    delete state[uri]
+    del(state, uri)
   },
   /**
    * Removes all entities from the Vuex store.
@@ -63,7 +61,7 @@ export const mutations: MutationTree<State> = {
    */
   purgeAll (state: State) : void {
     Object.keys(state).forEach(uri => {
-      delete state[uri]
+      del(state, uri)
     })
   },
   /**
@@ -72,7 +70,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the entity that is currently being deleted
    */
   deleting (state: State, uri: string) : void {
-    if (state[uri]) state[uri]._meta.deleting = true
+    if (state[uri]) set(state[uri]._meta, 'deleting', true)
   },
   /**
    * Marks a single entity in the Vuex store as normal again, after it has been marked as deleting before.
@@ -80,7 +78,7 @@ export const mutations: MutationTree<State> = {
    * @param uri   URI of the entity that failed to be deleted
    */
   deletingFailed (state: State, uri: string) : void {
-    if (state[uri]) state[uri]._meta.deleting = false
+    if (state[uri]) set(state[uri]._meta, 'deleting', false)
   }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,14 +21,18 @@ export default defineConfig({
     },
     rollupOptions: {
       // externalize outputs if we have these modules as dependencies
-      external: ['hal-json-normalizer', 'url-template'],
+      external: ['hal-json-normalizer', 'url-template', 'vue-demi'],
       output: {
         globals: {
           'url-template': 'parseTemplate',
-          'hal-json-normalizer': 'normalize'
+          'hal-json-normalizer': 'normalize',
+          'vue-demi': 'VueDemi'
         }
       }
     }
+  },
+  optimizeDeps: {
+    exclude: ['vue-demi']
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
Using https://github.com/vueuse/vue-demi/tree/main we are able to make the version compatible with v2 and v3. As we don't really use much of vue anyway this change was pretty minor.